### PR TITLE
Add Bitbucket Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Officially supported CI servers:
 - [Buildkite](https://buildkite.com)
 - [TaskCluster](http://docs.taskcluster.net)
 - [GoCD](https://www.go.cd/)
+- [Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines)
 
 Other CI tools using environment variables like `BUILD_ID` or `CI` would be detected as well.
 

--- a/index.js
+++ b/index.js
@@ -15,5 +15,6 @@ module.exports = !!(
   process.env.HUDSON_URL ||                      // Hudson
   (process.env.TASK_ID && process.env.RUN_ID) || // TaskCluster
   process.env.GO_PIPELINE_LABEL ||               // GoCD
+  process.env.BITBUCKET_COMMIT ||                // Bitbucket Pipelines
   false
 )


### PR DESCRIPTION
Add support for Bitbucket Pipelines (still in beta):

- [Product page](https://bitbucket.org/product/features/pipelines)
- [Environment variables documentation](https://confluence.atlassian.com/bitbucket/environment-variables-in-bitbucket-pipelines-794502608.html)