### PR TITLE
Remove hardcoded list of CI servers from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ CI server isn't properly detected :)
 
 ## Installation
 
-```
+```bash
 npm install is-ci --save
 ```
 
@@ -37,37 +37,13 @@ There's a few ways to do that:
 - Or provide the full path to the executable, e.g.
   `./node_modules/.bin/is-ci`
 
-```
+```bash
 is-ci && echo "This is a CI server"
 ```
 
 ## Supported CI tools
 
-Officially supported CI servers:
-
-- [AWS CodeBuild](https://aws.amazon.com/codebuild/)
-- [AppVeyor](http://www.appveyor.com)
-- [Bamboo](https://www.atlassian.com/software/bamboo) by Atlassian
-- [Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines)
-- [Buildkite](https://buildkite.com)
-- [CircleCI](http://circleci.com)
-- [Codeship](https://codeship.com)
-- [Drone](https://drone.io)
-- [GitLab CI](https://about.gitlab.com/gitlab-ci/)
-- [GoCD](https://www.go.cd/)
-- [Hudson](http://hudson-ci.org)
-- [Jenkins CI](https://jenkins-ci.org)
-- [Magnum CI](https://magnum-ci.com)
-- [Semaphore](https://semaphoreci.com)
-- [Solano CI](https://www.solanolabs.com/)
-- [Strider CD](https://strider-cd.github.io/)
-- [TaskCluster](http://docs.taskcluster.net)
-- [Team Foundation Server](https://www.visualstudio.com/en-us/products/tfs-overview-vs.aspx) by Microsoft
-- [TeamCity](https://www.jetbrains.com/teamcity/) by JetBrains
-- [Travis CI](http://travis-ci.org)
-
-Other CI tools using environment variables like `BUILD_ID` or `CI` would
-be detected as well.
+Refer [ci-info](https://github.com/watson/ci-info#supported-ci-tools) docs for all supported CI's
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ is-ci && echo "This is a CI server"
 
 ## Supported CI tools
 
-Refer [ci-info](https://github.com/watson/ci-info#supported-ci-tools) docs for all supported CI's
+Refer to [ci-info](https://github.com/watson/ci-info#supported-ci-tools) docs for all supported CI's
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "bin": "bin.js",
   "main": "index.js",
   "dependencies": {
-    "ci-info": "^1.*"
+    "ci-info": "^1.3.0"
   },
   "devDependencies": {
     "clear-require": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "bin": "bin.js",
   "main": "index.js",
   "dependencies": {
-    "ci-info": "^1.3.0"
+    "ci-info": "^1.*"
   },
   "devDependencies": {
     "clear-require": "^1.0.1",


### PR DESCRIPTION
I believe u won't introduce any breaking changes in the `MINOR` or `PATCH` versions, I saw that you update `is-ci` everytime you update `ci-info`.

Since this package just exports `ci-info` you could just simply point to the latest version it always. and can publish a new version of `is-ci` only when you make any major changes in `ci-info`.

So You don't have to maintain this repo unnecessarily and users don't have to wait too. 