### PR TITLE
Use const and let instead of var

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var assert = require('assert')
-var clearModule = require('clear-module')
+const assert = require('assert')
+const clearModule = require('clear-module')
 
 process.env.CI = 'true'
 
-var isCI = require('./')
+let isCI = require('./')
 assert(isCI)
 
 delete process.env.CI


### PR DESCRIPTION
Use `const` and `let` instead of `var` to conform to the [`no-var`](https://eslint.org/docs/rules/no-var) ESLint rule which is coming in a future version of [JavaScript Standard Style](https://standardjs.com). See https://github.com/standard/eslint-config-standard/pull/152.

This pull request only changes the `test.js` test file and therefore does not change any actual package files.