### PR TITLE
Add .github to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 .travis.yml
 test.js
+.github


### PR DESCRIPTION
The .github folder is published on npm, which is unnecessary: https://unpkg.com/browse/is-ci@3.0.0/
This PR adds it to the .npmignore file.
